### PR TITLE
Fixed #62: Rancher agent connection retry handling

### DIFF
--- a/agent/run.sh
+++ b/agent/run.sh
@@ -235,10 +235,18 @@ upgrade()
 
 wait_for()
 {
+    local url=$(echo "${CATTLE_URL}"| sed -e 's!/v1/scripts.*!/v1!')
+    info "Attempting to connect to: ${url}"
     for ((i=0; i < 300; i++)); do
-        if ! curl -f -s ${CATTLE_URL} >/dev/null 2>&1; then
-            error "${CATTLE_URL}" is not accessible
+        if ! curl -f -s ${url} >/dev/null 2>&1; then
+            error "${url}" is not accessible
+            sleep 2
+            if [ "$i" -eq "299" ]; then
+                error "Could not reach ${url}. Giving up."
+                exit 1
+            fi
         else
+            info "${url} is accessible"
             break
         fi
     done


### PR DESCRIPTION
Added a sleep to the for loop, and have it waiting 10 minutes for the
server to come available. Also, added some additional logging to let
users know it is attempting to reach server, unable to reach or can
reach.