### PR TITLE
Added new machine services to container

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,7 +3,8 @@ FROM ubuntu:14.04.1
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends openjdk-7-jre-headless \
                     curl \
-                    mysql-server
+                    mysql-server \
+                    xz-utils
 
 ENV CATTLE_HOME /var/lib/cattle
 ENV CATTLE_API_UI_INDEX http://cdn.rancher.io/ui/0.8.19/static/index.html
@@ -20,8 +21,17 @@ VOLUME ["/var/lib/cattle"]
 VOLUME ["/var/lib/mysql"]
 
 EXPOSE 8080
-ENV RANCHER_SERVER_IMAGE v0.10.0-rc1
+ENV RANCHER_SERVER_IMAGE v0.10.0-rc2
 
 EXPOSE 3306
 ADD https://github.com/rancherio/cattle/releases/download/v0.16.0/cattle.jar /usr/share/cattle/
+
+ADD https://github.com/docker/machine/releases/download/v0.1.0/docker-machine_linux-amd64 /usr/bin/docker-machine
+RUN chmod +x /usr/bin/docker-machine
+
+ADD https://github.com/rancherio/go-machine-service/releases/download/v0.1.0/go-machine-service.tar.xz /tmp/
+RUN tar xpvf /tmp/go-machine-service.tar.xz -C /usr/bin/ && \
+    chmod +x /usr/bin/go-machine-service
+
+
 CMD ["/usr/bin/s6-svscan", "/service"]


### PR DESCRIPTION
The docker-machine and go-machine-service binaries were added
to the server image. These are necessary to enable machine based
services in Rancher.