### PR TITLE
Fixed Bug wrong URL was used to check host availability

### DIFF
--- a/agent/run.sh
+++ b/agent/run.sh
@@ -239,7 +239,7 @@ wait_for()
     local url=$(echo "${CATTLE_URL}"| sed -e 's!/v1/scripts.*!/v1!')
     info "Attempting to connect to: ${url}"
     for ((i=0; i < 300; i++)); do
-        if ! curl -f -s ${url} >/dev/null 2>&1; then
+        if ! curl -f -s ${CATTLE_URL} >/dev/null 2>&1; then
             error "${url}" is not accessible
             sleep 2
             if [ "$i" -eq "299" ]; then


### PR DESCRIPTION
When authentication is turned on the URL used to check for server
availability was incorrect. We used the truncated version of the url
without credentials. We need to use the URL with the valid credentials
in order to register hosts with auth turned on.

This fixes issue in #142 