### PR TITLE
Add volmgr support

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && \
      ca-certificates \
      curl \
      iptables \
+     libaio1 \
      python-eventlet \
      python-minimal
 RUN curl -s https://bootstrap.pypa.io/get-pip.py > get-pip.py && python get-pip.py && rm get-pip.py
@@ -16,4 +17,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends nodejs
 RUN mkdir -p /var/lib/cattle /var/lib/rancher
 COPY register.py resolve_url.py agent.sh run.sh /
 ENTRYPOINT ["/run.sh"]
-ENV RANCHER_AGENT_IMAGE rancher/agent:v0.6.1
+ENV RANCHER_AGENT_IMAGE rancher/agent:v0.6.2

--- a/agent/run.sh
+++ b/agent/run.sh
@@ -81,6 +81,7 @@ launch_agent()
         -v /lib/modules:/lib/modules:ro \
         -v ${var_lib_docker}:${var_lib_docker} \
         -v /proc:/host/proc \
+        -v /dev:/host/dev \
         --volumes-from rancher-agent-state \
         "${RANCHER_AGENT_IMAGE}" "$@"
 }
@@ -224,6 +225,7 @@ run_bootstrap()
 
 run()
 {
+    mount --rbind /host/dev /dev
     while true; do
         run_bootstrap "$@" || true
         sleep 5


### PR DESCRIPTION
We need map of /dev, as well as a mount point can be shared for other containers

libaio is needed for pdata_tools, which used by volmgr for exporting device
mapper metadata