### PR TITLE
Pull docker-machine and go-machine-service binaries from cattle

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -35,14 +35,5 @@ ENV CATTLE_CATTLE_VERSION v0.56.0
 ADD https://github.com/rancherio/cattle/releases/download/${CATTLE_CATTLE_VERSION}/cattle.jar /usr/share/cattle/
 RUN /usr/share/cattle/install_cattle_binaries
 
-ENV CATTLE_DOCKER_MACHINE_VERSION v0.3.0-dev-packet-rc2
-ADD https://github.com/rancherio/machine/releases/download/${CATTLE_DOCKER_MACHINE_VERSION}/docker-machine /usr/bin/docker-machine
-RUN chmod +x /usr/bin/docker-machine
-
-ENV CATTLE_GO_MACHINE_SERVICE_VERSION v0.13.0
-ADD https://github.com/rancherio/go-machine-service/releases/download/${CATTLE_GO_MACHINE_SERVICE_VERSION}/go-machine-service.tar.xz /tmp/
-RUN tar xpvf /tmp/go-machine-service.tar.xz -C /usr/bin/ && \
-    chmod +x /usr/bin/go-machine-service
-
 ENV DEFAULT_CATTLE_MACHINE_EXECUTE true
 CMD ["/usr/bin/s6-svscan", "/service"]

--- a/server/artifacts/install_cattle_binaries
+++ b/server/artifacts/install_cattle_binaries
@@ -1,37 +1,40 @@
 #!/bin/bash
 
-set -e -x
+set -e 
 
 mkdir -p /tmp/extracted_cattle
 cd /tmp/extracted_cattle
 
-install_binary()
+install_build_tools()
 {
-    local src=${1}
-    local dest=${2}
-    local xz=${3:-"true"}
-
-    #deletes the longest possible match from the left
-    file=$(echo ${src##*/});
-
-    curl -L -o ${file} ${1}
-    if [ "$xz" = "true" ]; then
-        tar -xpJf ${file} -C ${dest}
-    fi
-    binary=$(echo ${file}|cut -d'.' -f1)
-    chmod +x ${dest}/${binary}
+    BUILD_TOOLS_VERSION="0.1.0"
+    tmpdir=$(mktemp -d)
+    pushd $tmpdir
+    curl -sSL -o build-tools.tar.gz https://github.com/rancherio/build-tools/archive/v${BUILD_TOOLS_VERSION}.tar.gz
+    tar -xzvf build-tools.tar.gz && cp ./build-tools-${BUILD_TOOLS_VERSION}/bin/* /usr/bin
+    popd
+    rm -rf ${tmpdir}
 }
 
-if [ -f "/usr/share/cattle/cattle.jar" ]; then
+unpack_jar()
+{
     unzip /usr/share/cattle/cattle.jar
     mkdir -p res && cd res
     unpack200 ../WEB-INF/lib/cattle-resources-*.jar.pack resources.jar
     unzip resources.jar
+}
 
-    for i in $(grep service\.package\.*\.url cattle-global.properties|cut -d"=" -f2); do
-        install_binary $i "/usr/bin"
-    done
+clean_up()
+{
+    cd /tmp
+    rm -rf ./extracted_cattle
+}
+
+trap clean_up EXIT SIGINT SIGTERM
+
+install_build_tools
+
+if [ -f "/usr/share/cattle/cattle.jar" ]; then
+    unpack_jar
+    /usr/bin/cattle-binary-pull ./cattle-global.properties /usr/bin
 fi
-
-cd /tmp
-rm -rf ./extracted_cattle

--- a/server/service/.s6-svscan/finish
+++ b/server/service/.s6-svscan/finish
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/bin/true


### PR DESCRIPTION
This PR updates the method of getting binaries from cattle-global.properties to use the common build-tool. This will now pull docker-machine and go-machine-service binaries from cattle as of PR rancherio/cattle#634

Also, setup s6 to not show crash errors on SIGTERM. 